### PR TITLE
Support permalink for persisting deep links

### DIFF
--- a/lib/torture/page_options.rb
+++ b/lib/torture/page_options.rb
@@ -31,7 +31,7 @@ module Torture
 
       # Render all snippets in one page. This is called within activity.md.erb, for example.
       def snippets(options)
-        page_header = Torture::Toc.Header(title, 1, {id: nil}) # FIXME: remove mutability.
+        page_header = Torture::Toc.Header(1, title, title, {id: nil}) # FIXME: remove mutability.
 
         level_to_header = {}
 

--- a/lib/torture/snippets.rb
+++ b/lib/torture/snippets.rb
@@ -43,11 +43,11 @@ class Snippets < Cell::ViewModel
   end
 
   # TODO: make library call
-  private def header_for(title, level)
+  private def header_for(title, permalink, level)
     top_header = @headers[level-1].last
     raise title unless top_header
 
-    @headers[level] << header = Torture::Toc::Header(title, level, top_header)
+    @headers[level] << header = Torture::Toc::Header(level, title, permalink, top_header)
     top_header.items << header
 
     return header, top_header
@@ -64,8 +64,8 @@ class Snippets < Cell::ViewModel
   # 4 render_header
 
   # Currently called "book".
-  def h2(title, name: title, level:2, display_title: title, **)
-    header, top_header = header_for(title, level)
+  def h2(title, permalink: title, name: title, level:2, display_title: title, **)
+    header, top_header = header_for(title, permalink, level)
 
     header = %{<h#{level} id="#{header.id}">#{display_title}</h#{level}> <!-- {#{header.id}-toc} -->}
 
@@ -77,8 +77,8 @@ class Snippets < Cell::ViewModel
     h2(title, level: 3, **options)
   end
 
-  def h4(title, level:4, **options) # FIXME: test me.
-    header, top_header = header_for(title, level)
+  def h4(title, permalink: title, level:4, **options) # FIXME: test me.
+    header, top_header = header_for(title, permalink, level)
 
     breadcrumb = %{<ul class="navigation">
     <li>#{top_header.title}</li>

--- a/lib/torture/toc.rb
+++ b/lib/torture/toc.rb
@@ -9,11 +9,11 @@ module Torture
     ]
   end
 
-    module Toc
+  module Toc
     Header = Struct.new(:title, :level, :id, :items)
 
-    def self.Header(title, level, higher_header)
-      id = [higher_header[:id], title].compact.join("-").downcase.gsub(/[^\w]/, "-").gsub(/-{2,}/, "-") # TODO: unit-test, asshole!
+    def self.Header(level, title, permalink, higher_header)
+      id = [higher_header[:id], permalink].compact.join("-").downcase.gsub(/[^\w]/, "-").gsub(/-{2,}/, "-") # TODO: unit-test, asshole!
 
       Header.new(title, level, id, [])
     end

--- a/test/cms/snippets/activity/intro.md.erb
+++ b/test/cms/snippets/activity/intro.md.erb
@@ -1,4 +1,4 @@
-<%= h2 "Intro" %>
+<%= h2 "Intro", permalink: 'Introduction' %>
 
 Hello!
 
@@ -7,3 +7,5 @@ Hello!
 Great, and then.
 
 <%= code "more" %>
+
+<%= h3 "Bye", permalink: 'bye bye' %>

--- a/test/torture_test.rb
+++ b/test/torture_test.rb
@@ -27,8 +27,8 @@ class TortureTest < Minitest::Spec
 
 <p><span class=\"divider\"></span></p>
 
-<h2 id=\"activity-intro\">Intro</h2>
-<p><!-- {activity-intro-toc} -->Hello!</p>
+<h2 id=\"activity-introduction\">Intro</h2>
+<p><!-- {activity-introduction-toc} -->Hello!</p>
 
 <pre><code class=\"ruby light code-snippet wow fadeIn\">
 true.must_equal true
@@ -38,6 +38,10 @@ true.must_equal true
 <pre><code class=\"ruby light code-snippet wow fadeIn\">
 9.must_equal 9
 </code></pre>
+<p><span class=\"divider\"></span></p>
+
+<h3 id=\"activity-introduction-bye-bye\">Bye</h3>
+<p><!-- {activity-introduction-bye-bye-toc} --></p>
 
 <p><span class=\"divider\"></span></p>
 
@@ -57,7 +61,7 @@ and profound</code></pre>
 </html>
 }
 
-    graph.inspect.must_equal %{#<struct Torture::Page::HTML::Graph level_to_header={1=>[#<struct Torture::Toc::Header title=\"Activity\", level=1, id=\"activity\", items=[#<struct Torture::Toc::Header title=\"Intro\", level=2, id=\"activity-intro\", items=[]>, #<struct Torture::Toc::Header title=\"Low Level\", level=2, id=\"activity-low-level\", items=[#<struct Torture::Toc::Header title=\"Deep & profound\", level=3, id=\"activity-low-level-deep-profound\", items=[]>]>]>, #<struct Torture::Toc::Header title=\"Activity\", level=1, id=\"activity\", items=[#<struct Torture::Toc::Header title=\"Intro\", level=2, id=\"activity-intro\", items=[]>, #<struct Torture::Toc::Header title=\"Low Level\", level=2, id=\"activity-low-level\", items=[#<struct Torture::Toc::Header title=\"Deep & profound\", level=3, id=\"activity-low-level-deep-profound\", items=[]>]>]>], 2=>[#<struct Torture::Toc::Header title=\"Intro\", level=2, id=\"activity-intro\", items=[]>, #<struct Torture::Toc::Header title=\"Low Level\", level=2, id=\"activity-low-level\", items=[#<struct Torture::Toc::Header title=\"Deep & profound\", level=3, id=\"activity-low-level-deep-profound\", items=[]>]>, #<struct Torture::Toc::Header title=\"Intro\", level=2, id=\"activity-intro\", items=[]>], 3=>[#<struct Torture::Toc::Header title=\"Deep & profound\", level=3, id=\"activity-low-level-deep-profound\", items=[]>], 4=>[], 5=>[]}, page_header=#<struct Torture::Toc::Header title=\"Activity\", level=1, id=\"activity\", items=[#<struct Torture::Toc::Header title=\"Intro\", level=2, id=\"activity-intro\", items=[]>, #<struct Torture::Toc::Header title=\"Low Level\", level=2, id=\"activity-low-level\", items=[#<struct Torture::Toc::Header title=\"Deep & profound\", level=3, id=\"activity-low-level-deep-profound\", items=[]>]>]>>}
+    graph.inspect.must_equal %{#<struct Torture::Page::HTML::Graph level_to_header={1=>[#<struct Torture::Toc::Header title=\"Activity\", level=1, id=\"activity\", items=[#<struct Torture::Toc::Header title=\"Intro\", level=2, id=\"activity-introduction\", items=[#<struct Torture::Toc::Header title=\"Bye\", level=3, id=\"activity-introduction-bye-bye\", items=[]>]>, #<struct Torture::Toc::Header title=\"Low Level\", level=2, id=\"activity-low-level\", items=[#<struct Torture::Toc::Header title=\"Deep & profound\", level=3, id=\"activity-low-level-deep-profound\", items=[]>]>]>, #<struct Torture::Toc::Header title=\"Activity\", level=1, id=\"activity\", items=[#<struct Torture::Toc::Header title=\"Intro\", level=2, id=\"activity-introduction\", items=[#<struct Torture::Toc::Header title=\"Bye\", level=3, id=\"activity-introduction-bye-bye\", items=[]>]>, #<struct Torture::Toc::Header title=\"Low Level\", level=2, id=\"activity-low-level\", items=[#<struct Torture::Toc::Header title=\"Deep & profound\", level=3, id=\"activity-low-level-deep-profound\", items=[]>]>]>], 2=>[#<struct Torture::Toc::Header title=\"Intro\", level=2, id=\"activity-introduction\", items=[#<struct Torture::Toc::Header title=\"Bye\", level=3, id=\"activity-introduction-bye-bye\", items=[]>]>, #<struct Torture::Toc::Header title=\"Low Level\", level=2, id=\"activity-low-level\", items=[#<struct Torture::Toc::Header title=\"Deep & profound\", level=3, id=\"activity-low-level-deep-profound\", items=[]>]>, #<struct Torture::Toc::Header title=\"Intro\", level=2, id=\"activity-introduction\", items=[#<struct Torture::Toc::Header title=\"Bye\", level=3, id=\"activity-introduction-bye-bye\", items=[]>]>], 3=>[#<struct Torture::Toc::Header title=\"Bye\", level=3, id=\"activity-introduction-bye-bye\", items=[]>, #<struct Torture::Toc::Header title=\"Deep & profound\", level=3, id=\"activity-low-level-deep-profound\", items=[]>, #<struct Torture::Toc::Header title=\"Bye\", level=3, id=\"activity-introduction-bye-bye\", items=[]>], 4=>[], 5=>[]}, page_header=#<struct Torture::Toc::Header title=\"Activity\", level=1, id=\"activity\", items=[#<struct Torture::Toc::Header title=\"Intro\", level=2, id=\"activity-introduction\", items=[#<struct Torture::Toc::Header title=\"Bye\", level=3, id=\"activity-introduction-bye-bye\", items=[]>]>, #<struct Torture::Toc::Header title=\"Low Level\", level=2, id=\"activity-low-level\", items=[#<struct Torture::Toc::Header title=\"Deep & profound\", level=3, id=\"activity-low-level-deep-profound\", items=[]>]>]>>}
 
     html_with_toc = Torture::Page::Final.new(nil).(:show, table_of_content: "_TOC_", html: html)
 
@@ -73,8 +77,8 @@ and profound</code></pre>
 
 <p><span class=\"divider\"></span></p>
 
-<h2 id=\"activity-intro\">Intro</h2>
-<p><!-- {activity-intro-toc} -->Hello!</p>
+<h2 id=\"activity-introduction\">Intro</h2>
+<p><!-- {activity-introduction-toc} -->Hello!</p>
 
 <pre><code class=\"ruby light code-snippet wow fadeIn\">
 true.must_equal true
@@ -84,6 +88,10 @@ true.must_equal true
 <pre><code class=\"ruby light code-snippet wow fadeIn\">
 9.must_equal 9
 </code></pre>
+<p><span class=\"divider\"></span></p>
+
+<h3 id=\"activity-introduction-bye-bye\">Bye</h3>
+<p><!-- {activity-introduction-bye-bye-toc} --></p>
 
 <p><span class=\"divider\"></span></p>
 
@@ -125,8 +133,8 @@ and profound</code></pre>
 
 <p><span class=\"divider\"></span></p>
 
-<h2 id=\"activity-intro\">Intro</h2>
-<p><!-- {activity-intro-toc} -->Hello!</p>
+<h2 id=\"activity-introduction\">Intro</h2>
+<p><!-- {activity-introduction-toc} -->Hello!</p>
 
 <pre><code class=\"ruby light code-snippet wow fadeIn\">
 </code></pre>
@@ -134,6 +142,10 @@ and profound</code></pre>
 
 <pre><code class=\"ruby light code-snippet wow fadeIn\">
 </code></pre>
+<p><span class=\"divider\"></span></p>
+
+<h3 id=\"activity-introduction-bye-bye\">Bye</h3>
+<p><!-- {activity-introduction-bye-bye-toc} --></p>
 
 <p><span class=\"divider\"></span></p>
 


### PR DESCRIPTION
Task - https://trello.com/c/gFomg4Hg/99-deep-linking

- Links can be made fixed by passing `permalink` keyword to header_tag methods
- No changes needed in existing header_tag calls.
- Only thing to consider is that we need to make sure to pass `permalink` if we're changing existing header.
- Thoughts ?