### PR TITLE
Use kradown to wrap code snippets over static HTML

### DIFF
--- a/lib/torture/snippets.rb
+++ b/lib/torture/snippets.rb
@@ -25,9 +25,7 @@ class Snippets < Cell::ViewModel
     end
 
     code = dont_extract ? code : extract(*args)
-
-    %{<pre><code class="ruby light code-snippet wow fadeIn">
-#{code}</code></pre>}
+    Kramdown::Document.new("\n\t#{code.gsub("\n", "\n\t")}").to_html
   end
 
   def show(snippet:, path:)


### PR DESCRIPTION
With this change, `<pre>` tag won't be wrapped again if it was done already.
This is helpful when `code` gets called inside any kramdown'ed block.

```
pre = Kramdown::Document.new(code).to_html
Kramdown::Document.new(pre).to_html == pre  # => true
```