### PR TITLE
Allow prepending filename in <code> snippets

### DIFF
--- a/lib/torture/snippets.rb
+++ b/lib/torture/snippets.rb
@@ -12,7 +12,16 @@ class Snippets < Cell::ViewModel
   def extract(section, **options)
     options = @model.merge(collapse: nil, unindent: true, **options)
 
-    Torture::Snippet.extract_from(file: File.join(options[:root], options[:file]), marker: section, collapse: options[:collapse], unindent: options[:unindent])
+    file = File.join(options[:root], options[:file])
+    filename = options[:show_filename] == true ? options[:file] : options[:show_filename]
+
+    Torture::Snippet.extract_from(
+      file: file,
+      filename: filename,
+      marker: section,
+      collapse: options[:collapse],
+      unindent: options[:unindent],
+    )
   end
 
   def code(*args)

--- a/test/cms/snippets/activity/intro.md.erb
+++ b/test/cms/snippets/activity/intro.md.erb
@@ -2,8 +2,8 @@
 
 Hello!
 
-<%= code "example" %>
+<%= code "example", show_filename: true %>
 
 Great, and then.
 
-<%= code "more" %>
+<%= code "more", show_filename: "concepts/more.rb" %>

--- a/test/torture_test.rb
+++ b/test/torture_test.rb
@@ -17,8 +17,12 @@ class TortureTest < Minitest::Spec
 
     html.must_equal %{<html>
   <title>
-    Activity  </title>
-  <%= table_of_content %>  <h2>Header</h2>
+    Activity
+  </title>
+  <%= table_of_content %>
+  
+<h2>Header</h2>
+
 <p>Some text.</p>
 
 <p>and more.</p>
@@ -28,32 +32,43 @@ class TortureTest < Minitest::Spec
 <p><span class=\"divider\"></span></p>
 
 <h2 id=\"activity-intro\">Intro</h2>
-<p><!-- {activity-intro-toc} -->Hello!</p>
+<p><!-- {activity-intro-toc} --></p>
 
-<pre><code class=\"ruby light code-snippet wow fadeIn\">
+<p>Hello!</p>
+
+<pre><code># basics_test.rb
+
 true.must_equal true
 </code></pre>
+
 <p>Great, and then.</p>
 
-<pre><code class=\"ruby light code-snippet wow fadeIn\">
+<pre><code># concepts/more.rb
+
 9.must_equal 9
 </code></pre>
 
 <p><span class=\"divider\"></span></p>
 
 <h2 id=\"activity-low-level\">Low Level</h2>
-<p><!-- {activity-low-level-toc} -->Deeper.</p>
+<p><!-- {activity-low-level-toc} --></p>
+
+<p>Deeper.</p>
 
 <p><span class=\"divider\"></span></p>
 
 <h3 id=\"activity-low-level-deep-profound\">Deep &amp; profound</h3>
-<p><!-- {activity-low-level-deep-profound-toc} -->test</p>
+<p><!-- {activity-low-level-deep-profound-toc} --></p>
 
-<pre><code class=\"ruby light code-snippet wow fadeIn\">
-99.must_equal 99
+<p>test</p>
+
+<pre><code>99.must_equal 99
 </code></pre>
-<pre><code class=\"ruby light code-snippet wow fadeIn\">
-and profound</code></pre>
+
+<pre><code>and profound
+</code></pre>
+
+
 </html>
 }
 
@@ -63,8 +78,12 @@ and profound</code></pre>
 
     html_with_toc.must_equal %{<html>
   <title>
-    Activity  </title>
-  _TOC_  <h2>Header</h2>
+    Activity
+  </title>
+  _TOC_
+  
+<h2>Header</h2>
+
 <p>Some text.</p>
 
 <p>and more.</p>
@@ -74,32 +93,43 @@ and profound</code></pre>
 <p><span class=\"divider\"></span></p>
 
 <h2 id=\"activity-intro\">Intro</h2>
-<p><!-- {activity-intro-toc} -->Hello!</p>
+<p><!-- {activity-intro-toc} --></p>
 
-<pre><code class=\"ruby light code-snippet wow fadeIn\">
+<p>Hello!</p>
+
+<pre><code># basics_test.rb
+
 true.must_equal true
 </code></pre>
+
 <p>Great, and then.</p>
 
-<pre><code class=\"ruby light code-snippet wow fadeIn\">
+<pre><code># concepts/more.rb
+
 9.must_equal 9
 </code></pre>
 
 <p><span class=\"divider\"></span></p>
 
 <h2 id=\"activity-low-level\">Low Level</h2>
-<p><!-- {activity-low-level-toc} -->Deeper.</p>
+<p><!-- {activity-low-level-toc} --></p>
+
+<p>Deeper.</p>
 
 <p><span class=\"divider\"></span></p>
 
 <h3 id=\"activity-low-level-deep-profound\">Deep &amp; profound</h3>
-<p><!-- {activity-low-level-deep-profound-toc} -->test</p>
+<p><!-- {activity-low-level-deep-profound-toc} --></p>
 
-<pre><code class=\"ruby light code-snippet wow fadeIn\">
-99.must_equal 99
+<p>test</p>
+
+<pre><code>99.must_equal 99
 </code></pre>
-<pre><code class=\"ruby light code-snippet wow fadeIn\">
-and profound</code></pre>
+
+<pre><code>and profound
+</code></pre>
+
+
 </html>
 }
   end
@@ -115,8 +145,12 @@ and profound</code></pre>
 
     html.must_equal %{<html>
   <title>
-    Activity  </title>
-  <%= table_of_content %>  <h2>Header</h2>
+    Activity
+  </title>
+  <%= table_of_content %>
+  
+<h2>Header</h2>
+
 <p>Some text.</p>
 
 <p>and more.</p>
@@ -126,29 +160,30 @@ and profound</code></pre>
 <p><span class=\"divider\"></span></p>
 
 <h2 id=\"activity-intro\">Intro</h2>
-<p><!-- {activity-intro-toc} -->Hello!</p>
+<p><!-- {activity-intro-toc} --></p>
 
-<pre><code class=\"ruby light code-snippet wow fadeIn\">
-</code></pre>
+<p>Hello!</p>
+
 <p>Great, and then.</p>
-
-<pre><code class=\"ruby light code-snippet wow fadeIn\">
-</code></pre>
 
 <p><span class=\"divider\"></span></p>
 
 <h2 id=\"activity-low-level\">Low Level</h2>
-<p><!-- {activity-low-level-toc} -->Deeper.</p>
+<p><!-- {activity-low-level-toc} --></p>
+
+<p>Deeper.</p>
 
 <p><span class=\"divider\"></span></p>
 
 <h3 id=\"activity-low-level-deep-profound\">Deep &amp; profound</h3>
-<p><!-- {activity-low-level-deep-profound-toc} -->test</p>
+<p><!-- {activity-low-level-deep-profound-toc} --></p>
 
-<pre><code class=\"ruby light code-snippet wow fadeIn\">
+<p>test</p>
+
+<pre><code>and profound
 </code></pre>
-<pre><code class=\"ruby light code-snippet wow fadeIn\">
-and profound</code></pre>
+
+
 </html>
 }
   end


### PR DESCRIPTION
Allows accepting `show_filename` kwarg in `code`. Below variations are supported.

```ruby
# Prepends "app/controllers/application_controller/api.rb"
<%= code "endpoint", file: "app/controllers/application_controller/api.rb", show_filename: true %>

# Prepends "api.rb"
<%= code "endpoint", file: "app/controllers/application_controller/api.rb", show_filename: "api.rb" %>
```

@apotonick There is a dependent `torture` PR to be merged before merging this - https://github.com/apotonick/torture/pull/2

Closes #5 